### PR TITLE
Add getCustomName (with a breaking change)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@
 import {EventEmitter} from 'events';
 import { Vec3 } from 'vec3';
 import { Item } from 'prismarine-item';
+import { ChatMessage } from 'prismarine-chat';
 
 declare module 'prismarine-entity' {
     export interface Effect {
@@ -42,6 +43,7 @@ declare module 'prismarine-entity' {
         player?: object;
         effects: Effect[];
         setEquipment(index: number, item: Item): void;
+        getCustomName(): ChatMessage | null;
     }
 
     export type EntityType = 'player' | 'mob' | 'object' | 'global' | 'orb' | 'other';

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = (version) => {
       if (name === undefined) {
         return null
       }
-      return new ChatMessage(name)
+      return ChatMessage.fromNotch(name)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,33 +1,40 @@
 const Vec3 = require('vec3').Vec3
-const util = require('util')
 const EventEmitter = require('events').EventEmitter
 
-module.exports = Entity
+module.exports = (version) => {
+  const ChatMessage = require('prismarine-chat')(version)
+  class Entity extends EventEmitter {
+    constructor (id) {
+      super()
+      this.id = id
+      this.position = new Vec3(0, 0, 0)
+      this.velocity = new Vec3(0, 0, 0)
+      this.yaw = 0
+      this.pitch = 0
+      this.onGround = true
+      this.height = 0
+      this.width = 0
+      this.effects = {}
+      // 0 = held item, 1-4 = armor slot
+      this.equipment = new Array(5)
+      this.heldItem = this.equipment[0] // shortcut to equipment[0]
+      this.isValid = true
+      this.metadata = []
+    }
 
-function Entity (id) {
-  EventEmitter.call(this)
-  this.id = id
-  this.type = null
-  this.position = new Vec3(0, 0, 0)
-  this.velocity = new Vec3(0, 0, 0)
-  this.yaw = 0
-  this.pitch = 0
-  this.onGround = true
-  this.height = 0
-  this.width = 0
-  this.effects = {}
-  // 0 = held item, 1-4 = armor slot
-  this.equipment = new Array(5)
-  this.heldItem = this.equipment[0] // shortcut to equipment[0]
-  this.isValid = true
-  this.metadata = []
-  this.noClip = false
-  this.vehicle = null
-  this.passenger = null
-}
-util.inherits(Entity, EventEmitter)
+    setEquipment (index, item) {
+      this.equipment[index] = item
+      this.heldItem = this.equipment[0]
+    }
 
-Entity.prototype.setEquipment = function (index, item) {
-  this.equipment[index] = item
-  this.heldItem = this.equipment[0]
+    getCustomName () {
+      const name = this.metadata[2]
+      if (name === undefined) {
+        return null
+      }
+      return new ChatMessage(name)
+    }
+  }
+
+  return Entity
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismarine-entity",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Represent a minecraft entity",
   "main": "index.js",
   "types": "index.d.ts",
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/node": "^17.0.4",
     "prismarine-item": "^1.4.0",
-    "standard": "^16.0.1"
+    "standard": "^16.0.1",
+    "prismarine-chat": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/PrismarineJS/prismarine-entity.git"
   },
   "dependencies": {
-    "vec3": "^0.1.4"
+    "vec3": "^0.1.4",
+    "prismarine-chat": "^1.4.1"
   },
   "keywords": [
     "minecraft",
@@ -28,7 +29,6 @@
   "devDependencies": {
     "@types/node": "^17.0.4",
     "prismarine-item": "^1.4.0",
-    "standard": "^16.0.1",
-    "prismarine-chat": "^1.4.1"
+    "standard": "^16.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismarine-entity",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "Represent a minecraft entity",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
the breaking change is that you now have to call prismarine-entity with a minecraft version. This is so that we can call prismarine-chat. In reality, I guess we could just specify any version but it's best to just give a minecraft version to prismarine-entity. I also made this an actual class to not use deprecated functions (`util.inherits`)