### PR TITLE
add lastPosition attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ If the entity type is `object`, this field will be set.
 If the entity type is `orb`, this field will be how much experience you
 get from collecting the orb.
 
+#### entity.lastPosition
+
 #### entity.position
 
 #### entity.velocity

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ declare module 'prismarine-entity' {
         name?: string;
         objectType?: string;
         count?: number;
+        lastPosition: Vec3;
         position: Vec3;
         velocity: Vec3;
         yaw: number;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = (version) => {
     constructor (id) {
       super()
       this.id = id
+      this.lastPosition = new Vec3(0, 0, 0)
       this.position = new Vec3(0, 0, 0)
       this.velocity = new Vec3(0, 0, 0)
       this.yaw = 0


### PR DESCRIPTION
Designed to keep track of the entity's position in the last tick, mainly so the developer can calculate the actual velocity for a given entity.

The reason I say "actual" velocity is because the velocity sent from the server doesn't reflect the entity's actual trajectory, it is designed to set the entity's velocity so that the client responds to those changes.

Rather than just creating a new attribute for the actual velocity, I think it would be better to introduce the `lastPosition` attribute so no needless calculation is done whilst managing many entities, and therefore negligible performance impact (primarily for mineflayer)