### PR TITLE
deprecate objectType and mobType

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,21 +23,27 @@ module.exports = (registryOrVersion) => {
       this.isValid = true
       this.metadata = []
     }
-    get mobType() {
+
+    get mobType () {
       printMobTypeWarning()
       return this.displayName
     }
-    set mobType(name) {
+
+    set mobType (name) {
       printMobTypeWarning()
       this.displayName = name
     }
-    get objectType() {
+
+    get objectType () {
       printObjectTypeWarning()
       return this.displayName
-    set objectType(name) {
+    }
+
+    set objectType (name) {
       printObjectTypeWarning()
       this.displayName = name
     }
+
     setEquipment (index, item) {
       this.equipment[index] = item
       this.heldItem = this.equipment[0]
@@ -61,9 +67,9 @@ module.exports = (registryOrVersion) => {
 
   return Entity
 }
-function printMobTypeWarning() {
-  console.log("Warning: entity.mobType is deprecated. Use entity.displayName instead")
+function printMobTypeWarning () {
+  console.log('Warning: entity.mobType is deprecated. Use entity.displayName instead')
 }
-function printObjectTypeWarning() {
-  console.log("Warning: entity.objectType is deprecated. Use entity.displayName instead")
+function printObjectTypeWarning () {
+  console.log('Warning: entity.objectType is deprecated. Use entity.displayName instead')
 }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,21 @@ module.exports = (registryOrVersion) => {
       this.isValid = true
       this.metadata = []
     }
-
+    get mobType() {
+      printMobTypeWarning()
+      return this.displayName
+    }
+    set mobType(name) {
+      printMobTypeWarning()
+      this.displayName = name
+    }
+    get objectType() {
+      printObjectTypeWarning()
+      return this.displayName
+    set objectType(name) {
+      printObjectTypeWarning()
+      this.displayName = name
+    }
     setEquipment (index, item) {
       this.equipment[index] = item
       this.heldItem = this.equipment[0]
@@ -46,4 +60,10 @@ module.exports = (registryOrVersion) => {
   }
 
   return Entity
+}
+function printMobTypeWarning() {
+  console.log("Warning: entity.mobType is deprecated. Use entity.displayName instead")
+}
+function printObjectTypeWarning() {
+  console.log("Warning: entity.objectType is deprecated. Use entity.displayName instead")
 }


### PR DESCRIPTION
it seems they are redundant, as nowhere in mineflayer or flying squid are they set without at the same time also setting displayName to the same value. 
Also, the Entity class fields are really confusing: the entity.type field is of the type "EntityType", while the field entity.entityType is not. I believe these two fields add to the confusion (since they bear no resemblance or analogy to the similarly named entity.entityType field) while also being useless.