### PR TITLE
Use getter for  `.heldItem`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ declare module 'prismarine-entity' {
         width: number;
         onGround: boolean;
         equipment: Array<Item>;
-        heldItem: Item;
+        get heldItem(): Item;
         metadata: Array<object>;
         isValid: boolean;
         health?: number;

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ module.exports = (registryOrVersion) => {
       this.effects = {}
       // 0 = held item, 1-4 = armor slot
       this.equipment = new Array(5)
-      this.heldItem = this.equipment[0] // shortcut to equipment[0]
       this.isValid = true
       this.metadata = []
     }
@@ -44,9 +43,12 @@ module.exports = (registryOrVersion) => {
       this.displayName = name
     }
 
+    get heldItem () {
+      return this.equipment[0]
+    }
+
     setEquipment (index, item) {
       this.equipment[index] = item
-      this.heldItem = this.equipment[0]
     }
 
     getCustomName () {


### PR DESCRIPTION
Uses [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) function for `.heldItem`.

related to https://github.com/PrismarineJS/mineflayer/issues/3224